### PR TITLE
modify the config to load from environment vars

### DIFF
--- a/config/bitbucket.php
+++ b/config/bitbucket.php
@@ -27,8 +27,8 @@ return [
     */
     'connections' => [
         'main'        => [
-            'token'  => 'your-token',
-            'method' => 'token'
+            'token'  => env('BB_AUTH_TOKEN', 'your-token'),
+            'method' => env('BB_AUTH_METHOD', 'token')
         ],
         'alternative' => [
             'clientId'     => 'your-client-id',


### PR DESCRIPTION
This encourages people to keep their sensitive config information out of source control. By default, it will fall back to the 2nd parameter values in the `env` method (available out of the box in Laravel 5+ via [phpdotenv](https://github.com/vlucas/phpdotenv)) which allows it to function as basic documentation if a user decides not to put this info in their `.env` file.
